### PR TITLE
Changed name_class to wm_name

### DIFF
--- a/wmctrl.py
+++ b/wmctrl.py
@@ -96,7 +96,7 @@ class Window(object):
 
     @classmethod
     def list_names(cls):
-        return uniq([w.name_class for w in cls.list()])
+        return uniq([w.wm_name for w in cls.list()])
 
     @classmethod
     def list_roles(cls):


### PR DESCRIPTION
Changed name_class to wm_name to actually return a list of window names instead of erroring out.