### PR TITLE
Improve way to get active window (works on archlinux)

### DIFF
--- a/wmctrl.py
+++ b/wmctrl.py
@@ -129,9 +129,8 @@ class Window(object):
     @classmethod
     def get_active(cls):
         out = getoutput("xprop -root _NET_ACTIVE_WINDOW")
-        parts = out.split()
         try:
-            id = int(parts[-1], 16)
+            id = int(out.split("# ")[1].split(", ")[0], 16)
         except ValueError:
             return None
         lst = cls.by_id(id)


### PR DESCRIPTION
Hi,

On my system (endeavourOS a arch-based distrib) the command :
```xprop -root _NET_ACTIVE_WINDOW```

return
```_NET_ACTIVE_WINDOW(WINDOW): window id # 0x280000b, 0x0```

Btw, id are not parsed correctly.

So i used this other way. Not the best (better using a regex) but works in both cases
